### PR TITLE
Add chat drafts to conversation state.

### DIFF
--- a/src/model/AppActions.js
+++ b/src/model/AppActions.js
@@ -426,6 +426,14 @@ export class AppActions {
     this._client.sendMessage({type: 'CHAT', text: body, channelId: conversationId});
   }
 
+  onDraftChat = (body: string, conversationId: number) => {
+    this._store.dispatch({
+      type: 'DRAFT_CHAT',
+      conversationId: conversationId,
+      text: body
+    });
+  }
+
   onSendGameChat = (body: string, gameId: number) => {
     if (this._isOffline()) {
       return;

--- a/src/model/conversation.js
+++ b/src/model/conversation.js
@@ -18,6 +18,7 @@ function createConversation(msg: KgsMessage) {
   let convo: Conversation = {
     id: msg.channelId,
     messages: [],
+    draft: '',
     status: isTempId(msg.channelId) ? 'pending' : 'created'
   };
   if (msg.callbackKey) {
@@ -170,6 +171,20 @@ export function handleConversationMessage(
       };
       return {...prevState, conversationsById};
     }
+  } else if (msg.type === 'DRAFT_CHAT') {
+    console.log('Drafting chat');
+    console.log(msg);
+    let convoId = msg.conversationId;
+    let conversationsById: Index<Conversation> = {...prevState.conversationsById};
+    if (conversationsById[convoId]) {
+      console.log('Found conversation!');
+      conversationsById[convoId] = {
+        ...conversationsById[convoId],
+        draft: msg.text
+      };
+      return {...prevState, conversationsById};
+    }
   }
+
   return prevState;
 }

--- a/src/model/types.js
+++ b/src/model/types.js
@@ -97,6 +97,7 @@ export type Conversation = {
   lastSeen?: number,
   unseenCount?: number,
   chatsDisabled?: boolean,
+  draft: string,
   messages: Array<ConversationMessage>,
   callbackKey?: ?number,
   status: 'pending' | 'created' | 'userNotFound' | 'closed'

--- a/src/ui/chat/ChatMessageBar.js
+++ b/src/ui/chat/ChatMessageBar.js
@@ -6,6 +6,7 @@ import type {Conversation} from '../../model';
 type Props = {
   conversation: ?Conversation,
   onSubmit: string => any;
+  onDraft: string => any;
 };
 
 export default class ChatMessageBar extends Component {
@@ -22,6 +23,13 @@ export default class ChatMessageBar extends Component {
     }
   }
 
+  _onChange(event: SyntheticEvent) {
+    let target: EventTarget = event.target;
+    if (target instanceof HTMLInputElement) {
+      this.props.onDraft(target.value);
+    }
+  }
+
   render() {
     let {conversation} = this.props;
     let placeholder;
@@ -30,6 +38,11 @@ export default class ChatMessageBar extends Component {
     } else {
       placeholder = 'Type a message...';
     }
+    // FIXME: This draft handling is a workaround for game chat
+    // storing conversation state differently from user and room chat.
+    // Ideally they'd work the same way and game chat drafts would be
+    // saved as well.
+    let draft = conversation ? conversation.draft : '';
     return (
       <div className='ChatMessageBar'>
         <div className='ChatMessageBar-inner'>
@@ -39,6 +52,8 @@ export default class ChatMessageBar extends Component {
               className='ChatMessageBar-input'
               type='text'
               placeholder={placeholder}
+              value={draft === '' ? null : draft}
+              onChange={this._onChange.bind(this)}
               autoFocus={!isTouchDevice()} />
           </form>
         </div>

--- a/src/ui/chat/ChatScreen.js
+++ b/src/ui/chat/ChatScreen.js
@@ -400,6 +400,7 @@ export default class ChatScreen extends Component {
               usersByName={usersByName}
               onUserDetail={actions.onUserDetail}
               onSendChat={this._onSendChat}
+              onDraftChat={this._onDraftChat}
               setMessagesDivRef={this._setMessagesDivRef}
               setMessageInputRef={this._setMessageInputRef} /> : null}
           {activeConv && activeRoom ?
@@ -420,6 +421,7 @@ export default class ChatScreen extends Component {
                 onJoinGame={actions.onJoinGame}
                 onSelectChallenge={actions.onSelectChallenge}
                 onSendChat={this._onSendChat}
+                onDraftChat={this._onDraftChat}
                 setMessagesDivRef={this._setMessagesDivRef}
                 setMessageInputRef={this._setMessageInputRef} />) : null}
         </div>
@@ -454,6 +456,14 @@ export default class ChatScreen extends Component {
       return;
     }
     this.props.actions.onSendChat(body, activeConversationId);
+  }
+
+  _onDraftChat = (body: string) => {
+    let {activeConversationId} = this.state;
+    if (!activeConversationId) {
+      return;
+    }
+    this.props.actions.onDraftChat(body, activeConversationId);
   }
 
   _onShowList = () => {

--- a/src/ui/chat/RoomChat.js
+++ b/src/ui/chat/RoomChat.js
@@ -29,6 +29,7 @@ export default class RoomChat extends Component {
     onSelectChallenge: number => any,
     onShowGames: (filter: GameFilter) => any,
     onSendChat: string => any,
+    onDraftChat: string => any,
     setMessagesDivRef: HTMLElement => any,
     setMessageInputRef: HTMLElement => any
   };
@@ -41,6 +42,7 @@ export default class RoomChat extends Component {
       usersByName,
       games,
       onUserDetail,
+      onDraftChat,
       onSendChat,
       onJoinGame,
       onSelectChallenge,
@@ -81,6 +83,7 @@ export default class RoomChat extends Component {
         <div className='RoomChat-message-bar' ref={setMessageInputRef}>
           <ChatMessageBar
             conversation={conversation}
+            onDraft={onDraftChat}
             onSubmit={onSendChat} />
         </div>
         {!isMobileScreen() ?

--- a/src/ui/chat/UserChat.js
+++ b/src/ui/chat/UserChat.js
@@ -20,6 +20,7 @@ export default class UserChat extends Component {
     usersByName: Index<User>,
     onUserDetail: string => any,
     onSendChat: string => any,
+    onDraftChat: string => any,
     setMessagesDivRef: HTMLElement => any,
     setMessageInputRef: HTMLElement => any
   };
@@ -32,6 +33,7 @@ export default class UserChat extends Component {
       usersByName,
       onUserDetail,
       onSendChat,
+      onDraftChat,
       setMessagesDivRef,
       setMessageInputRef
     } = this.props;
@@ -68,6 +70,7 @@ export default class UserChat extends Component {
         <div className='UserChat-message-bar' ref={setMessageInputRef}>
           <ChatMessageBar
             conversation={conversation}
+            onDraft={onDraftChat}
             onSubmit={onSendChat} />
         </div>
       </div>

--- a/src/ui/game/GameScreen.js
+++ b/src/ui/game/GameScreen.js
@@ -225,9 +225,12 @@ export default class GameScreen extends Component {
                   id: 0,
                   messages: [],
                   status: 'created',
+                  draft: '',
                   chatsDisabled: !game.tree
                 }}
-                onSubmit={this._onChat} />
+                onSubmit={this._onChat}
+                onDraft={()=>{}}
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
First of all, thanks for a great-looking app! I'm really looking forward to seeing this grow. I did some work on #92 because it seemed like a nice-sized task to start learning my way around the codebase.

This pull request allows drafts to be stored per conversation instead of keeping the same draft for all conversations, resolving #92. However, it doesn't (yet?) handle drafts in game chats (it ignores them), because those conversations are not stored in the same way as far as I can tell. I'd be happy to work on improving that as well, but I figured I'd go ahead and put this up for feedback first.

Disclaimer: I'm a backend developer by day and I don't have much experience with React/Flow, so if there are rookie mistakes, obvious problems, or you want to take a different approach that feedback is more than welcome. I also haven't figured out how to test against an API server that's not KGS itself, so I haven't tested submission of chat messages.