### PR TITLE
Fixes issue #115: "Game Info" option in "More" menu - opens modal with detailed game info.

### DIFF
--- a/src/css/_gamescreen.scss
+++ b/src/css/_gamescreen.scss
@@ -52,6 +52,10 @@ a.GameMoreMenu-dropdown-item {
   padding: 5px 10px;
 }
 
+.GameMoreMenu-game-info {
+  padding: 60px 20px 20px 20px;
+}
+
 .GameScreen-board {
   background: #555;
   margin: 0 auto;

--- a/src/ui/game/GameInfo.js
+++ b/src/ui/game/GameInfo.js
@@ -1,5 +1,6 @@
 // @flow
 import React, {PureComponent as Component} from 'react';
+import type { Children } from 'react';
 import GameTimeSystem from './GameTimeSystem';
 import {formatGameType, formatGameRuleset} from '../../model/game';
 import type {
@@ -10,13 +11,20 @@ import type {
 
 export default class GameInfo extends Component {
 
+  // NOTE There doesn't seem to be a standard way to type the children property
+  // using Flow. The Children type is being used here, but is currently defined
+  // as 'any' in the Flow source code, so this is mostly decoration. See:
+  // https://github.com/facebook/flow/issues/1964
+  // BD 2017-05-30
+
   props: {
     game: GameChannel,
-    roomsById: Index<Room>
+    roomsById: Index<Room>,
+    children?: Children,
   };
 
   render() {
-    let {game, roomsById} = this.props;
+    let {game, roomsById, children} = this.props;
     let rules = game.rules;
     let room = roomsById[game.roomId];
     let rows = [];
@@ -81,6 +89,7 @@ export default class GameInfo extends Component {
         <table className='GameInfo-table'>
           <tbody>
             {rows}
+            {children}
           </tbody>
         </table>
       </div>

--- a/src/ui/game/GameScreen.js
+++ b/src/ui/game/GameScreen.js
@@ -153,7 +153,8 @@ export default class GameScreen extends Component {
           {playing ? null :
             <GameMoreMenu
               game={game}
-              actions={actions} />}
+              actions={actions}
+              roomsById={roomsById} />}
         </div>
         <div className='GameScreen-main'>
           <BoardContainer


### PR DESCRIPTION
I've got my repository cleaned up and organized, so this is a re-do of my original pull request:

This fixes issue #115. GameMoreMenu componenet has been updated to include a 'More Info' modal that contains as much detailed game info as possible. A now deployment can be found here:

https://shinkgs-server-nokodgdtsw.now.sh

Screenshot of the new modal:

![shingkgs_screenshot_2](https://user-images.githubusercontent.com/798619/28080857-fe47dc10-6632-11e7-99d4-7eb8f0079b6a.png)
