### PR TITLE
add 5s and 15s byoyomi time choices to proposal form (for blitz)

### DIFF
--- a/src/ui/game/ProposalForm.js
+++ b/src/ui/game/ProposalForm.js
@@ -457,10 +457,12 @@ export default class ProposalForm extends Component {
     let {proposal} = this.props;
     let oldByoYomi = proposal.rules.byoYomiTime || 0;
     let byoYomiTime;
-    if (oldByoYomi <= 60) {
-      byoYomiTime = Math.max(10, oldByoYomi - 10);
+    if (oldByoYomi <= 20) {
+      byoYomiTime = Math.max(5, oldByoYomi - 5);
+    } else if (oldByoYomi <= 60) {
+      byoYomiTime = Math.max(5, oldByoYomi - 10);
     } else {
-      byoYomiTime = Math.max(10, oldByoYomi - 60);
+      byoYomiTime = Math.max(5, oldByoYomi - 60);
     }
     this.props.onChangeProposal(
       {...proposal, rules: {...proposal.rules, byoYomiTime}}
@@ -473,8 +475,10 @@ export default class ProposalForm extends Component {
     let byoYomiTime;
     if (oldByoYomi >= 60) {
       byoYomiTime = oldByoYomi + 60;
-    } else {
+    } else if (byoYomiTime >= 20) {
       byoYomiTime = oldByoYomi + 10;
+    } else {
+      byoYomiTime = oldByoYomi + 5;
     }
     this.props.onChangeProposal(
       {...proposal, rules: {...proposal.rules, byoYomiTime}}


### PR DESCRIPTION
A small tweak to the proposal form to allow not just 10s, 20s, 30s etc. byo-yomi times, but 5s, 10s, 15s, 20s, then 30s, 40s, etc. times. This is meant for more refined control for blitz, where 5s makes a big difference.

(In CGoban, the button increments are 10s below 60s, but you can manually enter any time in the time input box, which isn't possible with Shin KGS. Adding the 5s increments below 20s seemed like an elegant solution in keeping with your UI style.)