### PR TITLE
Add Tooltips to Icons

### DIFF
--- a/src/css/_user.scss
+++ b/src/css/_user.scss
@@ -19,12 +19,6 @@
   margin-left: 4px;
   line-height: 1;
   filter: grayscale(1) brightness(1.2) contrast(0.85);
-  &:hover {
-    .UserIcons-icon-tooltip {
-      transition-delay: 400ms;
-      visibility: visible;
-    }
-  }
 }
 
 .UserName-guest {
@@ -32,12 +26,6 @@
   margin-left: 4px;
   line-height: 1;
   filter: grayscale(1) brightness(1.4) contrast(0.85);
-  &:hover {
-    .UserIcons-icon-tooltip {
-      transition-delay: 400ms;
-      visibility: visible;
-    }
-  }
 }
 
 .UserName-selfish {
@@ -59,12 +47,6 @@
   width: 12px;
   height: 12px;
   line-height: 0.9;
-  &:hover {
-    .UserIcons-icon-tooltip {
-      transition-delay: 400ms;
-      visibility: visible;
-    }
-  }
 }
 
 .UserList-item {
@@ -101,7 +83,7 @@
   padding: 5px 5px;
   white-space: nowrap;
   position: absolute;
-  top: 100%;
+  top: 110%;
   right: 50%;
   z-index: 100;
   width: auto;

--- a/src/css/_user.scss
+++ b/src/css/_user.scss
@@ -19,6 +19,12 @@
   margin-left: 4px;
   line-height: 1;
   filter: grayscale(1) brightness(1.2) contrast(0.85);
+  &:hover {
+    .UserIcons-icon-tooltip {
+      transition-delay: 400ms;
+      visibility: visible;
+    }
+  }
 }
 
 .UserName-guest {
@@ -26,6 +32,12 @@
   margin-left: 4px;
   line-height: 1;
   filter: grayscale(1) brightness(1.4) contrast(0.85);
+  &:hover {
+    .UserIcons-icon-tooltip {
+      transition-delay: 400ms;
+      visibility: visible;
+    }
+  }
 }
 
 .UserName-selfish {
@@ -47,6 +59,16 @@
   width: 12px;
   height: 12px;
   line-height: 0.9;
+  &:hover {
+    .UserIcons-icon-tooltip {
+      transition-delay: 400ms;
+      visibility: visible;
+    }
+  }
+}
+
+.UserList-item {
+  position: relative;
 }
 
 .UserList-item-offline {
@@ -69,9 +91,32 @@
   margin-left: 4px;
 }
 
+.UserIcons-icon-tooltip {
+  visibility: hidden;
+  background-color: $inverted-bg;
+  color: $inverted-fg;
+  font-size: 14px;
+  line-height: 1;
+  border-radius: 4px;
+  padding: 5px 5px;
+  white-space: nowrap;
+  position: absolute;
+  top: 100%;
+  right: 50%;
+  z-index: 100;
+  width: auto;
+  transform: translate(50%);
+}
+
 .UserIcons-icon {
   display: inline-block;
   margin-right: 4px;
+  &:hover {
+    .UserIcons-icon-tooltip {
+      transition-delay: 400ms;
+      visibility: visible;
+    }
+  }
 }
 
 .UserDetailsModal-top-bar {

--- a/src/ui/user/UserIcons.js
+++ b/src/ui/user/UserIcons.js
@@ -2,8 +2,6 @@
 import React, {PureComponent as Component} from 'react';
 import type {User} from '../../model';
 
-const EMPTY_FLAGS = {};
-
 export default class UserIcons extends Component {
 
   props: {
@@ -11,38 +9,55 @@ export default class UserIcons extends Component {
   };
 
   render() {
-    let {user} = this.props;
-    let flags = user.flags || EMPTY_FLAGS;
+    const {user} = this.props;
+    const flags = user.flags || {};
     let icons = [];
-    if (user.authLevel === 'jr_admin') {
-      icons.push('⭐️');
-    } else if (user.authLevel === 'sr_admin' || user.authLevel === 'super_admin') {
-      icons.push('🌟');
-    } else if (user.authLevel === 'teacher') {
-      // icons.push('🎓');
+    switch(user.authLevel) {
+      case 'jr_admin':
+        icons.push({icon: '⭐️', name: 'Admin'});
+        break;
+      case 'sr_admin':
+        icons.push({icon: '🌟', name: 'Senior Admin'});
+        break;
+      case 'super_admin':
+        icons.push({icon: '🌠', name: 'Super Admin'});
+        break;
+      case 'teacher':
+        icons.push({icon: '🎓', name: 'Teacher'});
+        break;
     }
+
     if (flags.sleeping) {
-      icons.push('💤');
+      icons.push({icon:'💤', name: 'Sleeping'});
     }
     if (flags.kgsPlus) {
-      icons.push('🎩');
+      icons.push({icon:'🎩', name: 'KGS Plus'});
     }
-    // if (user.flags.playing || user.flags.playingTourney) {
-    //   icons.push('🎮');
-    // }
-    if (flags.tourneyWinner || flags.kgsMeijin) {
-      icons.push('🏆');
+
+    if (user.flags.playingTourney) {
+      icons.push({icon:'🕹️', name: 'Playing Tournament'});
+    } else if (user.flags.playing) {
+      icons.push({icon:'🎮', name: 'Playing'});
     }
-    if (flags.tourneyRunnerUp) {
-      icons.push('🏅');
+
+    if (flags.kgsMeijin) {
+      icons.push({icon:'🏆', name: 'KGS Meijin'});
+    } else if (flags.tourneyWinner) {
+      icons.push({icon:'🥇', name: 'Tournament Winner'});
+    } else if (flags.tourneyRunnerUp) {
+      icons.push({icon: '🥈', name: 'Tournament Runner-up'});
     }
+
     if (!icons.length) {
       return null;
     }
     return (
       <div className='UserIcons'>
-        {icons.map(icon =>
-          <div key={icon} className='UserIcons-icon'>{icon}</div>
+        {icons.map(({icon, name}) =>
+          <div key={icon} className='UserIcons-icon'>
+            {icon}
+            <div className='UserIcons-icon-tooltip'>{name}</div>
+          </div>
         )}
       </div>
     );

--- a/src/ui/user/UserIcons.js
+++ b/src/ui/user/UserIcons.js
@@ -13,18 +13,18 @@ export default class UserIcons extends Component {
     const flags = user.flags || {};
     let icons = [];
     switch(user.authLevel) {
-      case 'jr_admin':
-        icons.push({icon: '⭐️', name: 'Admin'});
-        break;
-      case 'sr_admin':
-        icons.push({icon: '🌟', name: 'Senior Admin'});
-        break;
-      case 'super_admin':
-        icons.push({icon: '🌠', name: 'Super Admin'});
-        break;
-      case 'teacher':
-        icons.push({icon: '🎓', name: 'Teacher'});
-        break;
+    case 'jr_admin':
+      icons.push({icon: '⭐️', name: 'Admin'});
+      break;
+    case 'sr_admin':
+      icons.push({icon: '🌟', name: 'Senior Admin'});
+      break;
+    case 'super_admin':
+      icons.push({icon: '🌠', name: 'Super Admin'});
+      break;
+    case 'teacher':
+      icons.push({icon: '🎓', name: 'Teacher'});
+      break;
     }
 
     if (flags.sleeping) {
@@ -34,9 +34,9 @@ export default class UserIcons extends Component {
       icons.push({icon:'🎩', name: 'KGS Plus'});
     }
 
-    if (user.flags.playingTourney) {
+    if (flags.playingTourney) {
       icons.push({icon:'🕹️', name: 'Playing Tournament'});
-    } else if (user.flags.playing) {
+    } else if (flags.playing) {
       icons.push({icon:'🎮', name: 'Playing'});
     }
 

--- a/src/ui/user/UserName.js
+++ b/src/ui/user/UserName.js
@@ -28,15 +28,15 @@ export default class UserName extends Component {
     let icons = (
       <div className='UserName-icons'>
         {flags.robot ?
-          <div className='UserName-robot'> 🤖<div className='UserIcons-icon-tooltip'>Robot</div></div> : null}
+          <div className='UserName-robot UserIcons-icon'> 🤖<div className='UserIcons-icon-tooltip'>Robot</div></div> : null}
         {flags.selfish ?
           <div className='UserName-selfish'>
-            <div className='UserName-selfish-icon'>~<div className='UserIcons-icon-tooltip'>Selfish</div></div>
+            <div className='UserName-selfish-icon UserIcons-icon'>~<div className='UserIcons-icon-tooltip'>Selfish</div></div>
           </div> :
           null}
         {flags.guest ?
           <div className='UserName-guest'>
-            <div className='UserName-selfish-icon'> 👤<div className='UserIcons-icon-tooltip'>Guest</div></div>
+            <div className='UserName-selfish-icon UserIcons-icon'> 👤<div className='UserIcons-icon-tooltip'>Guest</div></div>
           </div> :
           null}
         {extraIcons ? <UserIcons user={user} /> : null}

--- a/src/ui/user/UserName.js
+++ b/src/ui/user/UserName.js
@@ -27,9 +27,18 @@ export default class UserName extends Component {
     let flags = user.flags || EMPTY_FLAGS;
     let icons = (
       <div className='UserName-icons'>
-        {flags.robot ? <div className='UserName-robot'> 🤖</div> : null}
-        {flags.selfish ? <div className='UserName-selfish'><div className='UserName-selfish-icon'>~</div></div> : null}
-        {flags.guest ? <div className='UserName-guest'> 👤</div> : null}
+        {flags.robot ?
+          <div className='UserName-robot'> 🤖<div className='UserIcons-icon-tooltip'>Robot</div></div> : null}
+        {flags.selfish ?
+          <div className='UserName-selfish'>
+            <div className='UserName-selfish-icon'>~<div className='UserIcons-icon-tooltip'>Selfish</div></div>
+          </div> :
+          null}
+        {flags.guest ?
+          <div className='UserName-guest'>
+            <div className='UserName-selfish-icon'> 👤<div className='UserIcons-icon-tooltip'>Guest</div></div>
+          </div> :
+          null}
         {extraIcons ? <UserIcons user={user} /> : null}
       </div>
     );


### PR DESCRIPTION
Closes: https://github.com/jkk/shinkgs/issues/174

- All tooltips are centered in the user list bar because calculating positioning the tooltip without having it run outside of the container seemed like it was going to result in adding some really janky code, and having the tooltip overlap outside onto other containers seemed problematic and higher risk of regression.
- Changed some icons so that all were unique.
- `teacher`, `playing`, and `playingTourney` are now uncommented as icons.

I did my best to walk the line between incremental improvement and invasive/unnecessary refactoring.

![kapture 2018-05-18 at 17 01 03](https://user-images.githubusercontent.com/1584499/40257692-1b4c98e4-5abd-11e8-8e34-fa290e7a1390.gif)