### PR TITLE
Derive chat state from props [#233].

### DIFF
--- a/src/ui/game/GameScreen.js
+++ b/src/ui/game/GameScreen.js
@@ -48,16 +48,24 @@ type State = {
 };
 
 export default class GameScreen extends Component<Props, State> {
+  static getDerivedStateFromProps(props: Props, state: State) {
+    let { chatSections } = state;
+    let { game } = props;
+    let currentChatSections = getGameChatSections(game);
+
+    if (chatSections.length !== currentChatSections.length) {
+      return { ...state, chatSections: currentChatSections };
+    }
+
+    return null;
+  }
+
   state = {
     tab: "chat",
-    chatSections: getGameChatSections(this.props.game),
+    chatSections: [],
   };
 
   _chatScrollRef: ?HTMLElement;
-
-  /*  componentWillReceiveProps(nextProps: Props) {
-      this.setState({chatSections: getGameChatSections(nextProps.game)});
-    }*/
 
   _setChatScroll = () => {
     setTimeout(() => {


### PR DESCRIPTION
A section of the code was commented out that was responsible for updating the `chatSections` state depending on the incoming props. This kept all messages in the chat from displaying, since `chatSections` is  an empty array on initial render and would never get re-computed.

The original code used a method called `componentWillReceiveProps` that has since be renamed to `UNSAFE_componentWillReceiveProps`, which is probably the reason it was commented out. This PR uses the static method `getDerivedStateFromProps` to adjust the `chatSections` state in a safe manner. It only updates the state if it detects a difference in the number of messages displayed.

This resolves issue https://github.com/jkk/shinkgs/issues/233