### PR TITLE
KGS-174: Add title attribute to user icons

### DIFF
--- a/src/ui/user/UserIcons.js
+++ b/src/ui/user/UserIcons.js
@@ -8,44 +8,80 @@ type Props = {
   user: User,
 };
 
+type Icon = {
+  title: string,
+  value: string,
+};
+
+const getIcons = (user: User): Icon[] => {
+  const flags = user.flags || EMPTY_FLAGS;
+  const icons: Icon[] = [];
+
+  if (user.authLevel === "jr_admin") {
+    icons.push({
+      title: "Admin",
+      value: "⭐",
+    });
+  } else if (
+    user.authLevel === "sr_admin" ||
+    user.authLevel === "super_admin"
+  ) {
+    icons.push({
+      title: "Admin",
+      value: "🌟",
+    });
+  } else if (user.authLevel === "teacher") {
+    // icons.push({
+    //   title: "Teacher",
+    //   value: "🎓"
+    // });
+  }
+  if (flags.sleeping) {
+    icons.push({
+      title: "Sleeping",
+      value: "💤",
+    });
+  }
+  if (flags.kgsPlus) {
+    icons.push({
+      title: "KGS+",
+      value: "🎩",
+    });
+  }
+
+  // if (user.flags.playing || user.flags.playingTourney) {
+  //   icons.push({
+  //     title: "Playing",
+  //     value: "🎮",
+  //   });
+  // }
+
+  if (flags.tourneyWinner || flags.kgsMeijin) {
+    icons.push({
+      title: flags.kgsMeijin ? "KGS Meijin" : "Tournament Winner",
+      value: "🏆",
+    });
+  }
+  if (flags.tourneyRunnerUp) {
+    icons.push({
+      title: "Tournament Runner Up",
+      value: "🏅",
+    });
+  }
+
+  return icons;
+};
+
 export default class UserIcons extends Component<Props> {
   render() {
     let { user } = this.props;
-    let flags = user.flags || EMPTY_FLAGS;
-    let icons = [];
-    if (user.authLevel === "jr_admin") {
-      icons.push("⭐️");
-    } else if (
-      user.authLevel === "sr_admin" ||
-      user.authLevel === "super_admin"
-    ) {
-      icons.push("🌟");
-    } else if (user.authLevel === "teacher") {
-      // icons.push('🎓');
-    }
-    if (flags.sleeping) {
-      icons.push("💤");
-    }
-    if (flags.kgsPlus) {
-      icons.push("🎩");
-    }
-    // if (user.flags.playing || user.flags.playingTourney) {
-    //   icons.push('🎮');
-    // }
-    if (flags.tourneyWinner || flags.kgsMeijin) {
-      icons.push("🏆");
-    }
-    if (flags.tourneyRunnerUp) {
-      icons.push("🏅");
-    }
-    if (!icons.length) {
-      return null;
-    }
+    let icons = getIcons(user);
+
     return (
       <div className="UserIcons">
         {icons.map((icon) => (
-          <div key={icon} className="UserIcons-icon">
-            {icon}
+          <div key={icon.value} className="UserIcons-icon" title={icon.title}>
+            {icon.value}
           </div>
         ))}
       </div>

--- a/src/ui/user/UserName.js
+++ b/src/ui/user/UserName.js
@@ -26,7 +26,11 @@ export default class UserName extends Component<Props> {
     let icons = (
       <div className="UserName-icons">
         {flags.robot ? (
-          <span role="img" className="UserName-robot" aria-labelledby="robot">
+          <span
+            role="img"
+            className="UserName-robot"
+            aria-labelledby="robot"
+            title="Robot">
             {" "}
             🤖
           </span>
@@ -35,7 +39,8 @@ export default class UserName extends Component<Props> {
           <span
             role="img"
             className="UserName-selfish"
-            aria-labelledby="selfish">
+            aria-labelledby="selfish"
+            title="Selfish">
             <span
               role="img"
               className="UserName-selfish-icon"
@@ -45,7 +50,11 @@ export default class UserName extends Component<Props> {
           </span>
         ) : null}
         {flags.guest ? (
-          <span role="img" className="UserName-guest" aria-labelledby="guest">
+          <span
+            role="img"
+            className="UserName-guest"
+            aria-labelledby="guest"
+            title="Guest">
             {" "}
             👤
           </span>


### PR DESCRIPTION
## Ticket
Issue #174 

## Description
The initial request was to add some nice hover effect, but I think native `title` should fit much better. It's supported by all the browsers and exists from the beginning of time.

## Changes
- Add `title` attribute to user icons in `UserIcons`
- Add `title` attribute to additional icons in `UserName`

## Screenshots
![image](https://user-images.githubusercontent.com/4667275/91234121-e683cd80-e732-11ea-8f2b-95f402b8423e.png)

![image](https://user-images.githubusercontent.com/4667275/91234157-fb606100-e732-11ea-821e-7a8d57b5d7d7.png)
