### PR TITLE
fix(ui): Issue #183 - Fix UI bug with room links in small tablet view

### DIFF
--- a/src/css/_chat.scss
+++ b/src/css/_chat.scss
@@ -467,27 +467,25 @@ a.ChatMessages-game-deleted {
 }
 
 .RoomGameLinks {
-  // background: $chat-message-bg;
-  margin: 20px 0 0 0;
-  // margin-bottom: 20px;
-  // border-bottom: 2px solid $chat-divider;
-  // padding-bottom: 20px;
+  display: flex;
+  margin: 20px 0 -10px -10px;
+  flex-wrap: wrap;
+  align-items: center;
 }
 
 .RoomGameLink {
-  display: inline-block;
-  width: 49%;
+  display: block;
+  flex: 1 1 auto;
+  padding-left: 10px;
+  padding-bottom: 10px;
   line-height: 38px;
 
   a {
     display: block;
-    // background: $chat-message-bg;
-    // color: $link-color;
     border: 2px solid $very-muted;
     padding: 7px 10px 7px 10px;
     background: $content-bg;
     border-radius: 15px;
-    // max-width: 400px;
     font-size: 14px;
     box-sizing: border-box;
     height: 38px;
@@ -496,10 +494,6 @@ a.ChatMessages-game-deleted {
     &:active {
       border: 2px solid $muted;
     }
-  }
-
-  &:first-child {
-    margin-right: 2%;
   }
 }
 
@@ -512,21 +506,6 @@ a.ChatMessages-game-deleted {
   vertical-align: middle;
   font-size: 18px;
   margin: 0 10px 0 5px;
-}
-
-@media #{$mobile-query} {
-  .RoomGameLink {
-    display: block;
-    width: auto;
-
-    &:first-child {
-      margin-right: 0;
-    }
-  }
-
-  .RoomGameLink+.RoomGameLink {
-    margin-top: 5px;
-  }
 }
 
 .RoomGameLink-label {


### PR DESCRIPTION
## Issue

#183 

## Context

Buttons texts/copies are a bit broken on the small tablet size (vertical view). 

![image](https://user-images.githubusercontent.com/4667275/91702507-21459580-eb79-11ea-8ebb-e82913543f78.png)

## Changes

- Change styles from inline-block to flex
- Remove mobile query styles
- Add children-padding + negative parent-margin workaround for stacked view

## Screenshots
<details>
<summary>Table vertical (border-line state):</summary>

![image](https://user-images.githubusercontent.com/4667275/91704784-53a4c200-eb7c-11ea-9ca8-50799e517d05.png)
</details>

<details>
<summary>Tablet horizontal:</summary>

![image](https://user-images.githubusercontent.com/4667275/91704563-0de7f980-eb7c-11ea-972e-7094706d686d.png)
</details>

<details>
<summary>iPhone 6/7/8:</summary>

![image](https://user-images.githubusercontent.com/4667275/91704893-7c2cbc00-eb7c-11ea-9c89-daf94bdc652e.png)
</details>

<details>
<summary>iPhone SE (320px, small phone):</summary>

![image](https://user-images.githubusercontent.com/4667275/91704935-8bac0500-eb7c-11ea-83ee-5032feec50fd.png)
</details>
