### PR TITLE
Replace invalid usage of `aria-labelledby`

### DIFF
--- a/src/ui/user/UserName.js
+++ b/src/ui/user/UserName.js
@@ -26,7 +26,7 @@ export default class UserName extends Component<Props> {
     let icons = (
       <div className="UserName-icons">
         {flags.robot ? (
-          <span role="img" className="UserName-robot" aria-labelledby="robot">
+          <span role="img" className="UserName-robot" title="robot">
             {" "}
             🤖
           </span>
@@ -35,17 +35,17 @@ export default class UserName extends Component<Props> {
           <span
             role="img"
             className="UserName-selfish"
-            aria-labelledby="selfish">
+            title="selfish">
             <span
               role="img"
               className="UserName-selfish-icon"
-              aria-labelledby="selfish">
+              title="selfish">
               ~
             </span>
           </span>
         ) : null}
         {flags.guest ? (
-          <span role="img" className="UserName-guest" aria-labelledby="guest">
+          <span role="img" className="UserName-guest" title="guest">
             {" "}
             👤
           </span>


### PR DESCRIPTION
`aria-labelledby` expects an ID that references another element, the contents of which are to be used as the label. Here, we use "robot", "selfish", and "guest", but these are not references to named elements, but text values.

Instead, `aria-label` should be used. However, `aria-label` does not reveal its contents to normal users (only screen readers) and there is improved discoverability for new KGS users as to what `~` means, for instance, so using `title` (which screen readers understand) providers both an accessible label and some discoverable name to all users.

Some overlap with #241